### PR TITLE
Fix: Fixes crash on Icinga PowerShell Framework 1.3.0

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -9,7 +9,13 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## 1.2.0 (pending)
 
+### Enhancement
+
 * Adds check for current configured PowerShell execution policies
+
+### Bugfixes
+
+* [#7](https://github.com/Icinga/icinga-powershell-kickstart/pull/7) Fixes crash with Icinga PowerShell Framework v1.3.0
 
 ## 1.1.0 (2020-06-02)
 

--- a/script/icinga-powershell-kickstart.ps1
+++ b/script/icinga-powershell-kickstart.ps1
@@ -84,7 +84,7 @@ function Start-IcingaFrameworkWizard()
         try {
             # First import the module into our current shell
             if ((Test-Path $ModuleDir)) {
-                Import-Module (Join-Path -Path $ModuleDir -ChildPath 'icinga-powershell-framework.psm1');
+                Import-Module (Join-Path -Path $ModuleDir -ChildPath 'icinga-powershell-framework') -Global -Force;
             }
         } catch {
             # Todo: Log output


### PR DESCRIPTION
Starting with Icinga for Windows v1.3.0 we added some new handling on how the Framework is loaded. For that reason the old kickstarter failed, as the loading process for importing the module referenced to the wrong base file.