### PR TITLE
Feature: Updates Kickstart for Icinga for Windows 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ Once loaded, it will be executed and asks all required questions on how and wher
 
 ```powershell
 [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11";
-$ProgressPreference = "SilentlyContinue";
+$ProgressPreference                         = "SilentlyContinue";
 
-$global:IcingaFrameworkKickstartSource = 'https://raw.githubusercontent.com/Icinga/icinga-powershell-kickstart/master/script/icinga-powershell-kickstart.ps1';
+Invoke-WebRequest `
+    -UseBasicParsing `
+    -Uri 'https://packages.icinga.com/IcingaForWindows/IcingaForWindows.ps1' `
+    -OutFile 'C:\Users\Public\IcingaForWindows.ps1';
 
-$Script = (Invoke-WebRequest -UseBasicParsing -Uri $global:IcingaFrameworkKickstartSource).Content;
-$Script += "`r`n`r`n Start-IcingaFrameworkWizard;";
-
-Invoke-Command -ScriptBlock ([Scriptblock]::Create($Script));
+& 'C:\Users\Public\IcingaForWindows.ps1'
 ```
+
+More details and examples can be found on the [Icinga documentation](https://icinga.com/docs/icinga-for-windows/latest/doc/02-Installation/).
 
 ## Documentation
 

--- a/doc/01-Introduction.md
+++ b/doc/01-Introduction.md
@@ -1,10 +1,10 @@
 Introduction
 ===
 
-The Icinga PowerShell Kickstart is a simple PowerShell script allowing users to easily install and deploy the [Icinga PowerShell Framwork](https://icinga.com/docs/windows/latest) on Windows machines by either using GitHub repositories or internal sources for the Zip-Package.
+The Icinga PowerShell Kickstart is a simple PowerShell script allowing users to easily install and deploy the [Icinga PowerShell Framework](https://icinga.com/docs/windows/latest) on Windows machines by using the Icinga for Windows repository manager.
 
 Once the Framework is installed the entire installation of Icinga Agents including many different components is possible.
 
-The Kickstart script allows to specify a custom location for the script as well in case the Windows machines can not access the internet and only rely on internal resources.
+The Kickstart script will lookup the source of the components being installed, depending on the provided argument configuration.
 
 Please have a look on the [Installation Guide of the Framework](https://icinga.com/docs/windows/latest/doc/02-Installation/) on how to proceed.

--- a/doc/30-Upgrading-Kickstart.md
+++ b/doc/30-Upgrading-Kickstart.md
@@ -4,6 +4,10 @@ Upgrading Icinga PowerShell Kickstart is usually quite straightforward.
 
 Specific version upgrades are described below. Please note that version updates are incremental.
 
+## Upgrading to v1.3.0 (2021-09-07)
+
+No special steps required.
+
 ## Upgrading to v1.2.0 (2020-12-01)
 
 No special steps required.

--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,18 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-kickstart/milestones?state=closed).
 
+## 1.3.0 (2021-09-07)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/2?closed=1)
+
+### General
+
+* Adds `IcingaForWindows.ps1` just for change tracking, as this script is hosted on [packages.icinga.com](https://packages.icinga.com/IcingaForWindows/) for easier accessibility
+
+### Enhancement
+
+* [#9](https://github.com/Icinga/icinga-powershell-kickstart/pull/9) Prepares Kickstart script for Icinga for Windows v1.6.0 and the new repository management
+
 ## 1.2.0 (2020-12-01)
 
 ### Enhancement

--- a/icinga-powershell-kickstart.psd1
+++ b/icinga-powershell-kickstart.psd1
@@ -1,0 +1,29 @@
+@{
+    ModuleVersion     = '1.3.0'
+    GUID              = '875189b7-cfc2-44c0-817d-f754f40aae64'
+    Author            = 'Lord Hepipud'
+    CompanyName       = 'Icinga GmbH'
+    Copyright         = '(c) 2021 Icinga GmbH | MIT'
+    Description       = 'Icinga for Windows kickstart for easier deployment of the Icinga PowerShell Framework.'
+    PowerShellVersion = '4.0'
+    NestedModules     = @()
+    FunctionsToExport = @( '*' )
+    CmdletsToExport   = @( '*' )
+    VariablesToExport = '*'
+    AliasesToExport   = @( '*' )
+    PrivateData       = @{
+        PSData     = @{
+            Tags         = @( 'icinga', 'icinga2', 'IcingaKickstart', 'IcingaPowerShell', 'IcingaforWindows', 'IcingaWindows')
+            LicenseUri   = 'https://github.com/Icinga/icinga-powershell-kickstart/blob/master/LICENSE'
+            ProjectUri   = 'https://github.com/Icinga/icinga-powershell-kickstart'
+            ReleaseNotes = 'https://github.com/Icinga/icinga-powershell-kickstart/releases'
+        };
+        Version    = 'v1.3.0';
+        Name       = 'Windows Kickstart';
+        Type       = 'kickstart';
+        Function   = 'Start-IcingaFrameworkWizard';
+        Endpoint   = '';
+        ScriptFile = 'script\icinga-powershell-kickstart.ps1';
+    }
+    HelpInfoURI       = 'https://github.com/Icinga/icinga-powershell-kickstart'
+}

--- a/script/IcingaForWindows.ps1
+++ b/script/IcingaForWindows.ps1
@@ -1,0 +1,171 @@
+<#PSScriptInfo
+.VERSION
+    1.3
+.GUID
+    112e3823-c9ad-4d33-a92c-32c9db86a0d6
+.DESCRIPTION
+    Icinga for Windows installation script
+
+    This script is designed and simple quick start, to fetch the following files from a provided repository:
+
+    * icinga-powershell-kickstart
+    * icinga-powershell-framework
+
+    Both packages will be read from the the provided 'IcingaRepository' URL and installed from this location.
+.AUTHOR
+    Lord Hepipud
+.COMPANYNAME
+    Icinga GmbH
+.COPYRIGHT
+    (c) 2021 Icinga GmbH | GPLv2
+.LICENSEURI
+    https://github.com/Icinga/icinga-powershell-kickstart/blob/master/LICENSE
+.PROJECTURI
+    https://github.com/Icinga/icinga-powershell-kickstart
+#>
+
+<#
+.SYNOPSIS
+    Icinga for Windows installation script
+.DESCRIPTION
+    Icinga for Windows installation script
+
+    This script is designed and simple quick start, to fetch the following files from a provided repository:
+
+    * icinga-powershell-kickstart
+    * icinga-powershell-framework
+
+    Both packages will be read from the the provided 'IcingaRepository' URL and installed from this location.
+.PARAMETER IcingaRepository
+    The location (local, web or network share) of your Icinga for Windows repository. Defaults to 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json'
+.PARAMETER ModuleDirectory
+    Allows to specify in which PowerShell directory Icinga for Windows will be installed. If left empty, you will be prompted with a dialog, asking on where
+    Icinga for Windows should be installed into. Defaults to empty
+.PARAMETER AnswerFile
+    Allows you to provide an answer file, starting with Icinga for Windows 1.6.0, which will apply the specified configuration after the Framework has been installed
+.PARAMETER InstallCommand
+    Allows you to provide an install command, starting with Icinga for Windows 1.6.0, which will apply the specified configuration after the Framework has been installed
+.PARAMETER AllowUpdate
+    Defines if the Icinga PowerShell Framework should be updated during the kickstart run, in case it is already installed
+.PARAMETER SkipWizard
+    Defines to only install the Icinga PowerShell Framework and/or update it if specified. Will skip the question for the installation wizard/Icinga Management Console
+    afterwards and will ignore provided arguments -AnswerFile and -InstallCommand
+.LINK
+    https://icinga.com/docs/icinga-for-windows/latest/doc/02-Installation/
+    https://github.com/Icinga/icinga-powershell-kickstart
+    https://packages.icinga.com/IcingaForWindows/
+#>
+
+param (
+    [string]$IcingaRepository = 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json',
+    [string]$ModuleDirectory  = $null,
+    [string]$AnswerFile       = '',
+    [string]$InstallCommand   = '',
+    [switch]$AllowUpdate      = $FALSE,
+    [switch]$SkipWizard       = $FALSE
+);
+
+function Install-IcingaKickstart()
+{
+    param (
+        [string]$IcingaRepository = 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json',
+        [string]$ModuleDirectory  = $null,
+        [string]$AnswerFile       = '',
+        [string]$InstallCommand   = '',
+        [switch]$AllowUpdate      = $null,
+        [switch]$SkipWizard       = $FALSE
+    );
+
+    Add-Type -Assembly 'System.IO.Compression.FileSystem';
+
+    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11";
+    $ProgressPreference                         = "SilentlyContinue";
+
+    try {
+        $RepositoryFile = (Invoke-WebRequest -UseBasicParsing -Uri $IcingaRepository -ErrorAction Stop).Content;
+    } catch {
+        if ($IcingaRepository[-1] -eq '/') {
+            $IcingaRepository = [string]::Format('{0}ifw.repo.json', $IcingaRepository);
+        } else {
+            $IcingaRepository = [string]::Format('{0}/ifw.repo.json', $IcingaRepository);
+        }
+
+        try {
+            $RepositoryFile = (Invoke-WebRequest -UseBasicParsing -Uri $IcingaRepository -ErrorAction Stop).Content;
+        } catch {
+            Write-Host $_.Exception.Message;
+            return;
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($RepositoryFile)) {
+        Write-Host 'No repository file found';
+        return;
+    }
+
+    $RepoData         = ConvertFrom-Json -InputObject $RepositoryFile;
+    $KickstartPackage = $RepoData.Packages.Kickstart | Sort-Object Version -Descending | Select-Object -First 1;
+    $FrameworkPackage = $RepoData.Packages.Framework | Sort-Object Version -Descending | Select-Object -First 1;
+    $FrameworkUrl     = '';
+    $KickstartUrl    = '';
+
+    if ($null -eq $FrameworkPackage -Or $null -eq $KickstartPackage) {
+        throw 'No Icinga PowerShell Framework or Icinga PowerShell Kickstart package found';
+        return;
+    }
+
+    if ($FrameworkPackage.RelativePath) {
+        $FrameworkUrl = [string]::Format('{0}/{1}', $RepoData.Info.RemoteSource, $FrameworkPackage.Location);
+    } else {
+        $FrameworkUrl = $FrameworkPackage.Location;
+    }
+
+    if ($KickstartPackage.RelativePath) {
+        $KickstartUrl = [string]::Format('{0}/{1}', $RepoData.Info.RemoteSource, $KickstartPackage.Location);
+    } else {
+        $KickstartUrl = $KickstartPackage.Location;
+    }
+
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $KickstartUrl -OutFile (Join-Path -Path $ENV:TEMP -ChildPath 'icinga-powershell-kickstart.zip') -ErrorAction Stop;
+    } catch {
+        throw ([string]::Format('Unable to download kickstart package from "{0}"', $KickstartUrl));
+    }
+
+    $Kickstarter   = [System.IO.Compression.ZipFile]::OpenRead((Join-Path -Path $ENV:TEMP -ChildPath 'icinga-powershell-kickstart.zip'));
+    $ScriptContent = $null;
+
+    foreach ($entry in $Kickstarter.Entries) {
+        if ($entry.Name -eq 'icinga-powershell-kickstart.ps1') {
+            $FileStream    = $entry.Open();
+            $FileReader    = New-Object 'System.IO.StreamReader' $FileStream;
+            $ScriptContent = $FileReader.ReadToEnd();
+            $FileReader.Dispose();
+            break;
+        }
+    }
+
+    $Kickstarter.Dispose();
+
+    Remove-Item -Path (Join-Path -Path $ENV:TEMP -ChildPath 'icinga-powershell-kickstart.zip');
+
+    $ScriptContent += "`r`n`r`n";
+    $ScriptContent += '$KickStartArguments = $args[0];';
+    $ScriptContent += "`r`n";
+
+    [hashtable]$KickStartArguments = @{
+        '-RepositoryUrl'   = $FrameworkUrl;
+        '-ModuleDirectory' = $ModuleDirectory;
+        '-AllowUpdate'     = $AllowUpdate;
+        '-AnswerFile'      = $AnswerFile;
+        '-InstallCommand'  = $InstallCommand;
+        '-SkipWizard'      = $SkipWizard;
+        '-IfW160'          = $TRUE;
+    };
+
+    $ScriptContent = [string]::Format('{0}Start-IcingaFrameworkWizard @KickStartArguments', $ScriptContent);
+
+    Invoke-Command -ScriptBlock ([Scriptblock]::Create($ScriptContent)) -ArgumentList $KickStartArguments;
+}
+
+Install-IcingaKickstart @args;


### PR DESCRIPTION
Updates the Icinga for Windows kickstart to properly work with v1.6.0, by supporting the repository management.

This also added a new, smaller entry point to read repository content for Framework and Kickstart, to deploy them inside the environment more easily.