### PR TITLE
Fix: Framework install error on folder lock

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,13 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-kickstart/milestones?state=closed).
 
-## 1.4.0 (2021-11-09)
+## 1.4.0 (2022-02-09)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/3?closed=1)
 
 ### Bugfixes
 
 * [#12](https://github.com/Icinga/icinga-powershell-kickstart/pull/12) Fixes kickstart exception on Framework installation on PowerShell 7
+* [#15](https://github.com/Icinga/icinga-powershell-kickstart/pull/15) Fixes installation error for Icinga PowerShell Framework caused by a folder lock for virus scanners as example
 
 ## 1.3.0 (2021-09-07)
 


### PR DESCRIPTION
In some environments the kickstart might fail during the rename task of the Icinga PowerShell Framework folder to the target name, because of file locks caused by virus scanners for example.

We now add retry loop for several attempts with a 4 second sleep, waiting until the folder lock is released and trying to rename the folder again.